### PR TITLE
Bug fix that allowed static param to also be shared

### DIFF
--- a/test/test_pipelines/test_pipeline_fixtures.py
+++ b/test/test_pipelines/test_pipeline_fixtures.py
@@ -48,6 +48,15 @@ def two_stock_df() -> pd.DataFrame:
     return pd.DataFrame.from_dict(data)
 
 
+def similar_field_name_df() -> pd.DataFrame:
+    data = {
+        "id": [0, 1, 2, 3, 4, 5],
+        "tsm_gross_income": [150, 160, 170, 180, 190, 200],
+        "total_gross_income": [25, 20, 40, 30, 35, 45],
+    }
+    return pd.DataFrame.from_dict(data)
+
+
 def std_check_function(stock_gross_income: Any, stock_expenses: Any) -> bool:
     """"""
     expected = 140
@@ -64,6 +73,16 @@ def series_check_function(stock_gross_income: pd.Series, stock_expenses: pd.Seri
     """
     results = []
     for gi, e in zip(stock_gross_income, stock_expenses):
+        if gi - e == 140:
+            results.append(True)
+            continue
+        results.append(False)
+    return pd.Series(results)
+
+
+def same_name_check(total_gross_income: pd.Series, carrier_gross_income: pd.Series):
+    results = []
+    for gi, e in zip(total_gross_income, carrier_gross_income):
         if gi - e == 140:
             results.append(True)
             continue

--- a/test/test_pipelines/test_pipeline_workflow.py
+++ b/test/test_pipelines/test_pipeline_workflow.py
@@ -2,7 +2,7 @@ import pytest
 
 from dirlin.pipeline import Check, Validation, Report, Pipeline
 from test.test_pipelines.test_pipeline_fixtures import single_stock_df, std_check_function, two_stock_df, \
-    single_stock_df_b, series_check_function
+    single_stock_df_b, series_check_function, same_name_check, similar_field_name_df
 
 _shared_param_with_single_field = single_stock_df, std_check_function
 """testing class aims to test use cases where a test function has a shared parameter,
@@ -86,6 +86,21 @@ def test_pipeline_workflow_series_function():
 
     pipeline.add_report_set(
         report=report2, validation=validation
+    )
+
+    y = pipeline.run_error_log()
+    print(y)
+
+
+def test_pipeline_workflow_similar_param_name():
+    check1 = Check(same_name_check)
+    validation = Validation([check1])
+
+    report1 = Report(df=similar_field_name_df())
+
+    pipeline = Pipeline()
+    pipeline.add_report_set(
+        report=report1, validation=validation
     )
 
     y = pipeline.run_error_log()


### PR DESCRIPTION
There was a previous bug where if I had a check function that had similar base names, but one of them was a static parameter, that it would cause weird behaviors in the function. This update fixes that.

Example: function(total_expense, stock_expense) and a df had `total expense` and `tsm_expense` as fields.